### PR TITLE
Fragments for H+b and H+c samples

### DIFF
--- a/fragments/HPlusBottom_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8.py
+++ b/fragments/HPlusBottom_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8.py
@@ -6,9 +6,10 @@ from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import 
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 
 import os
+
 # https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
 
-gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+gridpack_file='HPlusBottom_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),
@@ -30,7 +31,7 @@ generator = cms.EDFilter('Pythia8HadronizerFilter',
         pythia8PSweightsSettingsBlock,
         pythia8aMCatNLOSettingsBlock,
         processParameters = cms.vstring(
-            'TimeShower:nPartonsInBorn = 0', # number of coloured particles (before resonance decays) in born matrix element
+            'TimeShower:nPartonsInBorn = 2', # number of coloured particles (before resonance decays) in born matrix element
             'SLHA:useDecayTable = off',
             '25:m0 = 125',
             '25:onMode = off',

--- a/fragments/HPlusBottom_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
+++ b/fragments/HPlusBottom_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
@@ -6,9 +6,10 @@ from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import 
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 
 import os
+
 # https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
 
-gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+gridpack_file='HPlusBottom_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),
@@ -30,11 +31,8 @@ generator = cms.EDFilter('Pythia8HadronizerFilter',
         pythia8PSweightsSettingsBlock,
         pythia8aMCatNLOSettingsBlock,
         processParameters = cms.vstring(
-            'TimeShower:nPartonsInBorn = 0', # number of coloured particles (before resonance decays) in born matrix element
+            'TimeShower:nPartonsInBorn = 2', # number of coloured particles (before resonance decays) in born matrix element
             'SLHA:useDecayTable = off',
-            '25:m0 = 125',
-            '25:onMode = off',
-            '25:onIfMatch = 22 22',
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/fragments/HPlusBottom_5FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnloFXFX_pythia8.py
+++ b/fragments/HPlusBottom_5FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnloFXFX_pythia8.py
@@ -6,9 +6,10 @@ from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import 
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 
 import os
+
 # https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
 
-gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+gridpack_file='HPlusBottom_5FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnloFXFX_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),
@@ -30,7 +31,18 @@ generator = cms.EDFilter('Pythia8HadronizerFilter',
         pythia8PSweightsSettingsBlock,
         pythia8aMCatNLOSettingsBlock,
         processParameters = cms.vstring(
-            'TimeShower:nPartonsInBorn = 0', # number of coloured particles (before resonance decays) in born matrix element
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
             'SLHA:useDecayTable = off',
             '25:m0 = 125',
             '25:onMode = off',

--- a/fragments/HPlusBottom_5FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8.py
+++ b/fragments/HPlusBottom_5FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8.py
@@ -6,9 +6,10 @@ from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import 
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 
 import os
+
 # https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
 
-gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+gridpack_file='HPlusBottom_5FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),

--- a/fragments/HPlusBottom_5FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnloFXFX_JHUGenV7011_pythia8.py
+++ b/fragments/HPlusBottom_5FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnloFXFX_JHUGenV7011_pythia8.py
@@ -6,9 +6,10 @@ from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import 
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 
 import os
+
 # https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
 
-gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+gridpack_file='HPlusBottom_5FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnloFXFX_JHUGenV7011_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),
@@ -30,11 +31,19 @@ generator = cms.EDFilter('Pythia8HadronizerFilter',
         pythia8PSweightsSettingsBlock,
         pythia8aMCatNLOSettingsBlock,
         processParameters = cms.vstring(
-            'TimeShower:nPartonsInBorn = 0', # number of coloured particles (before resonance decays) in born matrix element
+           'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
             'SLHA:useDecayTable = off',
-            '25:m0 = 125',
-            '25:onMode = off',
-            '25:onIfMatch = 22 22',
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/fragments/HPlusBottom_5FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
+++ b/fragments/HPlusBottom_5FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
@@ -1,4 +1,4 @@
-import FWCore.ParameterSet.Config as cms
+iimport FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
@@ -6,9 +6,10 @@ from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import 
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 
 import os
+
 # https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
 
-gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+gridpack_file='HPlusBottom_5FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),
@@ -32,9 +33,6 @@ generator = cms.EDFilter('Pythia8HadronizerFilter',
         processParameters = cms.vstring(
             'TimeShower:nPartonsInBorn = 0', # number of coloured particles (before resonance decays) in born matrix element
             'SLHA:useDecayTable = off',
-            '25:m0 = 125',
-            '25:onMode = off',
-            '25:onIfMatch = 22 22',
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/fragments/HPlusCharm_3FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8.py
+++ b/fragments/HPlusCharm_3FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+# https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('__GRIDPACK__'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter('Pythia8HadronizerFilter',
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt.pdl'),
+            convertPythiaCodes = cms.untracked.bool(False)
+        ),
+        parameterSets = cms.vstring('EvtGen130')
+    ),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'TimeShower:nPartonsInBorn = 2', # number of coloured particles (before resonance decays) in born matrix element
+            'SLHA:useDecayTable = off',
+            '25:m0 = 125',
+            '25:onMode = off',
+            '25:onIfMatch = 22 22',
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PSweightsSettings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+        )
+    )
+)

--- a/fragments/HPlusCharm_3FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8.py
+++ b/fragments/HPlusCharm_3FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8.py
@@ -1,19 +1,23 @@
 import FWCore.ParameterSet.Config as cms
 
-# https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
-
-externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
-    args = cms.vstring('__GRIDPACK__'),
-    nEvents = cms.untracked.uint32(5000),
-    numberOfParameters = cms.uint32(1),
-    outputFile = cms.string('cmsgrid_final.lhe'),
-    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
-)
-
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+import os
+
+# https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
+
+gridpack_file='HPlusCharm_3FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),
+    nEvents = cms.untracked.uint32(9999),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
 
 generator = cms.EDFilter('Pythia8HadronizerFilter',
     maxEventsToPrint = cms.untracked.int32(1),
@@ -21,14 +25,6 @@ generator = cms.EDFilter('Pythia8HadronizerFilter',
     filterEfficiency = cms.untracked.double(1.0),
     pythiaHepMCVerbosity = cms.untracked.bool(False),
     comEnergy = cms.double(13000.),
-    ExternalDecays = cms.PSet(
-        EvtGen130 = cms.untracked.PSet(
-            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
-            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt.pdl'),
-            convertPythiaCodes = cms.untracked.bool(False)
-        ),
-        parameterSets = cms.vstring('EvtGen130')
-    ),
     PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CP5SettingsBlock,

--- a/fragments/HPlusCharm_3FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
+++ b/fragments/HPlusCharm_3FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+# https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('__GRIDPACK__'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter('Pythia8HadronizerFilter',
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt.pdl'),
+            convertPythiaCodes = cms.untracked.bool(False)
+        ),
+        parameterSets = cms.vstring('EvtGen130')
+    ),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'TimeShower:nPartonsInBorn = 2', # number of coloured particles (before resonance decays) in born matrix element
+            'SLHA:useDecayTable = off',
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PSweightsSettings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+        )
+    )
+)

--- a/fragments/HPlusCharm_3FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
+++ b/fragments/HPlusCharm_3FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
@@ -1,19 +1,22 @@
 import FWCore.ParameterSet.Config as cms
 
-# https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
-
-externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
-    args = cms.vstring('__GRIDPACK__'),
-    nEvents = cms.untracked.uint32(5000),
-    numberOfParameters = cms.uint32(1),
-    outputFile = cms.string('cmsgrid_final.lhe'),
-    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
-)
-
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+import os
+# https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
+
+gridpack_file='HPlusCharm_3FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),
+    nEvents = cms.untracked.uint32(9999),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
 
 generator = cms.EDFilter('Pythia8HadronizerFilter',
     maxEventsToPrint = cms.untracked.int32(1),
@@ -21,14 +24,6 @@ generator = cms.EDFilter('Pythia8HadronizerFilter',
     filterEfficiency = cms.untracked.double(1.0),
     pythiaHepMCVerbosity = cms.untracked.bool(False),
     comEnergy = cms.double(13000.),
-    ExternalDecays = cms.PSet(
-        EvtGen130 = cms.untracked.PSet(
-            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
-            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt.pdl'),
-            convertPythiaCodes = cms.untracked.bool(False)
-        ),
-        parameterSets = cms.vstring('EvtGen130')
-    ),
     PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CP5SettingsBlock,

--- a/fragments/HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnloFXFX_pythia8.py
+++ b/fragments/HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnloFXFX_pythia8.py
@@ -8,7 +8,7 @@ from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 import os
 # https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
 
-gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnloFXFX_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),
@@ -30,7 +30,18 @@ generator = cms.EDFilter('Pythia8HadronizerFilter',
         pythia8PSweightsSettingsBlock,
         pythia8aMCatNLOSettingsBlock,
         processParameters = cms.vstring(
-            'TimeShower:nPartonsInBorn = 0', # number of coloured particles (before resonance decays) in born matrix element
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 4', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
             'SLHA:useDecayTable = off',
             '25:m0 = 125',
             '25:onMode = off',

--- a/fragments/HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8.py
+++ b/fragments/HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+# https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('__GRIDPACK__'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter('Pythia8HadronizerFilter',
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt.pdl'),
+            convertPythiaCodes = cms.untracked.bool(False)
+        ),
+        parameterSets = cms.vstring('EvtGen130')
+    ),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'TimeShower:nPartonsInBorn = 0', # number of coloured particles (before resonance decays) in born matrix element
+            'SLHA:useDecayTable = off',
+            '25:m0 = 125',
+            '25:onMode = off',
+            '25:onIfMatch = 22 22',
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PSweightsSettings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+        )
+    )
+)

--- a/fragments/HPlusCharm_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnloFXFX_JHUGenV7011_pythia8.py
+++ b/fragments/HPlusCharm_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnloFXFX_JHUGenV7011_pythia8.py
@@ -8,7 +8,7 @@ from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 import os
 # https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
 
-gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToGG_M125_TuneCP5_13TeV_amcatnlo_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnloFXFX_JHUGenV7011_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),
@@ -30,11 +30,19 @@ generator = cms.EDFilter('Pythia8HadronizerFilter',
         pythia8PSweightsSettingsBlock,
         pythia8aMCatNLOSettingsBlock,
         processParameters = cms.vstring(
-            'TimeShower:nPartonsInBorn = 0', # number of coloured particles (before resonance decays) in born matrix element
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 4', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
             'SLHA:useDecayTable = off',
-            '25:m0 = 125',
-            '25:onMode = off',
-            '25:onIfMatch = 22 22',
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/fragments/HPlusCharm_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
+++ b/fragments/HPlusCharm_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+# https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('__GRIDPACK__'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter('Pythia8HadronizerFilter',
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt.pdl'),
+            convertPythiaCodes = cms.untracked.bool(False)
+        ),
+        parameterSets = cms.vstring('EvtGen130')
+    ),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'TimeShower:nPartonsInBorn = 0', # number of coloured particles (before resonance decays) in born matrix element
+            'SLHA:useDecayTable = off',
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PSweightsSettings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+        )
+    )
+)

--- a/fragments/HPlusCharm_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
+++ b/fragments/HPlusCharm_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8.py
@@ -1,19 +1,22 @@
 import FWCore.ParameterSet.Config as cms
 
-# https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
-
-externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
-    args = cms.vstring('__GRIDPACK__'),
-    nEvents = cms.untracked.uint32(5000),
-    numberOfParameters = cms.uint32(1),
-    outputFile = cms.string('cmsgrid_final.lhe'),
-    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
-)
-
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+import os
+# https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/HIG-RunIISummer19UL17wmLHEGEN-00105/0
+
+gridpack_file='HPlusCharm_4FS_MuRFScaleDynX0p50_HToZZTo4L_M125_TuneCP5_13TeV_amcatnlo_JHUGenV7011_pythia8_slc7_amd64_gcc820_CMSSW_10_6_19_tarball.tar.xz'
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring(os.environ['PWD']+'/'+gridpack_file),
+    nEvents = cms.untracked.uint32(9999),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
 
 generator = cms.EDFilter('Pythia8HadronizerFilter',
     maxEventsToPrint = cms.untracked.int32(1),
@@ -21,14 +24,6 @@ generator = cms.EDFilter('Pythia8HadronizerFilter',
     filterEfficiency = cms.untracked.double(1.0),
     pythiaHepMCVerbosity = cms.untracked.bool(False),
     comEnergy = cms.double(13000.),
-    ExternalDecays = cms.PSet(
-        EvtGen130 = cms.untracked.PSet(
-            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
-            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt.pdl'),
-            convertPythiaCodes = cms.untracked.bool(False)
-        ),
-        parameterSets = cms.vstring('EvtGen130')
-    ),
     PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CP5SettingsBlock,


### PR DESCRIPTION
Adding fragments for H+b and H+c samples, the fragments are intended to be used with gridpacks stored at /afs/cern.ch/work/m/missirol/public/for_selvaggi/higgsPlusCharm/gridpacks/220310. In the fragments I removed the lines concerning EvtGen. 